### PR TITLE
Fix #399: UI changes for optional content

### DIFF
--- a/projects/common-consumption/src/lib/card/toc-card/toc-card.component.html
+++ b/projects/common-consumption/src/lib/card/toc-card/toc-card.component.html
@@ -17,7 +17,7 @@
     attr.aria-pressed="{{activeContent?.sbUniqueIdentifier === content?.sbUniqueIdentifier}}" tabindex="0"
     [ngClass]="{'active': activeContent?.sbUniqueIdentifier === content?.sbUniqueIdentifier}">
 
-    <div mat-line>{{content?.relationalMetadata?.optional? "Addition Material: ":""}}{{content?.name}}</div>
+    <div mat-line>{{ content?.relationalMetadata?.optional ? "Addition Material: " + content?.name : content?.name }}</div>
     <div mat-line *ngIf="content?.relationalMetadata?.optional" style="color: gray; font-size: smaller;"> This material is optional and will not impact your course progress% or final score</div>
     <img width="32" height="32" [src]="content?.appIcon || fallbackImg" (error)="img.src = fallbackImg" alt="" #img />
 
@@ -63,7 +63,7 @@
       class="sb_success_check" alt="Complated Icon" mat-list-icon>
     <img width="32" height="32" [src]="content?.appIcon || fallbackImg" (error)="img.src = fallbackImg"
       alt="{{content?.name}} Image" #img mat-list-icon />
-      <div mat-line>{{content?.relationalMetadata?.optional? "Addition Material: ":""}}{{content?.name}}</div>
+      <div mat-line>{{ content?.relationalMetadata?.optional ? "Addition Material: " + content?.name : content?.name }}</div>
       <div mat-line *ngIf="content?.relationalMetadata?.optional" style="color: gray; font-size: smaller;"> This material is optional and will not impact your course progress% or final score</div>
     <div mat-line *ngIf="bestScoreLabel">{{bestScoreLabel}}</div>
     <button class="sbchapter__play__btn" *ngIf="!isTrackable(content) && playBtnConfig.show"
@@ -113,7 +113,7 @@
       </i>
       <img [src]="fallbackImg" width="32" height="32" *ngIf="!content?.appIcon" alt="image" #img />
     </div>
-    <div mat-line>{{content?.relationalMetadata?.optional? "Addition Material: ":""}}{{content?.name}}</div>
+    <div mat-line>{{ content?.relationalMetadata?.optional ? "Addition Material: " + content?.name : content?.name }}</div>
     <div mat-line *ngIf="content?.relationalMetadata?.optional" style="color: gray; font-size: smaller;"> This material is optional and will not impact your course progress% or final score</div>
     <div mat-line *ngIf="bestScoreLabel && displayScore">{{bestScoreLabel}}</div>
 
@@ -166,7 +166,7 @@
       </i>
       <img [src]="fallbackImg" width="32" height="32" *ngIf="!content?.appIcon" alt="image" #img />
     </div>
-    <div mat-line>{{content?.relationalMetadata?.optional? "Addition Material: ":""}}{{content?.name}}</div>
+    <div mat-line>{{ content?.relationalMetadata?.optional ? "Addition Material: " + content?.name : content?.name }}</div>
     <div mat-line *ngIf="content?.relationalMetadata?.optional" style="color: gray; font-size: smaller;"> This material is optional and will not impact your course progress% or final score</div>
     <div mat-line *ngIf="bestScoreLabel && displayScore">{{bestScoreLabel}}</div>
     <button class="sbchapter__play__btn"

--- a/projects/common-consumption/src/lib/card/toc-card/toc-card.component.html
+++ b/projects/common-consumption/src/lib/card/toc-card/toc-card.component.html
@@ -62,7 +62,9 @@
       class="sb_success_check" alt="Complated Icon" mat-list-icon>
     <img width="32" height="32" [src]="content?.appIcon || fallbackImg" (error)="img.src = fallbackImg"
       alt="{{content?.name}} Image" #img mat-list-icon />
+      <div *ngIf="content?.relationalMetadata?.optional">Optional</div>
     <div mat-line>{{content?.name}}</div>
+    <div mat-line *ngIf="content?.relationalMetadata?.optional" style="color: gray; font-size: smaller;"> This material is optional and will not impact your course progress</div>
     <div mat-line *ngIf="bestScoreLabel">{{bestScoreLabel}}</div>
     <button class="sbchapter__play__btn" *ngIf="!isTrackable(content) && playBtnConfig.show"
       (click)="$event.stopImmediatePropagation(); $event.preventDefault(); onPlayButtonClick($event)" tabindex="0">

--- a/projects/common-consumption/src/lib/card/toc-card/toc-card.component.html
+++ b/projects/common-consumption/src/lib/card/toc-card/toc-card.component.html
@@ -17,7 +17,8 @@
     attr.aria-pressed="{{activeContent?.sbUniqueIdentifier === content?.sbUniqueIdentifier}}" tabindex="0"
     [ngClass]="{'active': activeContent?.sbUniqueIdentifier === content?.sbUniqueIdentifier}">
 
-    <div mat-line>{{content?.name}}</div>
+    <div mat-line>{{content?.relationalMetadata?.optional? "Addition Material: ":""}}{{content?.name}}</div>
+    <div mat-line *ngIf="content?.relationalMetadata?.optional" style="color: gray; font-size: smaller;"> This material is optional and will not impact your course progress% or final score</div>
     <img width="32" height="32" [src]="content?.appIcon || fallbackImg" (error)="img.src = fallbackImg" alt="" #img />
 
   </mat-list-item>
@@ -62,9 +63,8 @@
       class="sb_success_check" alt="Complated Icon" mat-list-icon>
     <img width="32" height="32" [src]="content?.appIcon || fallbackImg" (error)="img.src = fallbackImg"
       alt="{{content?.name}} Image" #img mat-list-icon />
-      <div *ngIf="content?.relationalMetadata?.optional">Optional</div>
-    <div mat-line>{{content?.name}}</div>
-    <div mat-line *ngIf="content?.relationalMetadata?.optional" style="color: gray; font-size: smaller;"> This material is optional and will not impact your course progress</div>
+      <div mat-line>{{content?.relationalMetadata?.optional? "Addition Material: ":""}}{{content?.name}}</div>
+      <div mat-line *ngIf="content?.relationalMetadata?.optional" style="color: gray; font-size: smaller;"> This material is optional and will not impact your course progress% or final score</div>
     <div mat-line *ngIf="bestScoreLabel">{{bestScoreLabel}}</div>
     <button class="sbchapter__play__btn" *ngIf="!isTrackable(content) && playBtnConfig.show"
       (click)="$event.stopImmediatePropagation(); $event.preventDefault(); onPlayButtonClick($event)" tabindex="0">
@@ -113,7 +113,8 @@
       </i>
       <img [src]="fallbackImg" width="32" height="32" *ngIf="!content?.appIcon" alt="image" #img />
     </div>
-    <div mat-line>{{content?.name}}</div>
+    <div mat-line>{{content?.relationalMetadata?.optional? "Addition Material: ":""}}{{content?.name}}</div>
+    <div mat-line *ngIf="content?.relationalMetadata?.optional" style="color: gray; font-size: smaller;"> This material is optional and will not impact your course progress% or final score</div>
     <div mat-line *ngIf="bestScoreLabel && displayScore">{{bestScoreLabel}}</div>
 
   </mat-list-item>
@@ -165,7 +166,8 @@
       </i>
       <img [src]="fallbackImg" width="32" height="32" *ngIf="!content?.appIcon" alt="image" #img />
     </div>
-    <div >{{content?.name}}</div>
+    <div mat-line>{{content?.relationalMetadata?.optional? "Addition Material: ":""}}{{content?.name}}</div>
+    <div mat-line *ngIf="content?.relationalMetadata?.optional" style="color: gray; font-size: smaller;"> This material is optional and will not impact your course progress% or final score</div>
     <div mat-line *ngIf="bestScoreLabel && displayScore">{{bestScoreLabel}}</div>
     <button class="sbchapter__play__btn"
       *ngIf="!(content?.contentData?.trackable?.enabled === 'Yes') && playBtnConfig.show"


### PR DESCRIPTION
## Overview


1. This PR fixes [Differentiating of optional materials & regular contents in the consumption portal #399 ](https://github.com/Sunbird-Ed/SunbirdEd-consumption-ngcomponents/issues/399)
2. This PR does the following: Add an optional material tag if the content is optional in the trackable collection. 

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

![Screenshot from 2023-09-04 13-33-45](https://github.com/Sunbird-Ed/SunbirdEd-consumption-ngcomponents/assets/86031203/7e147c39-447e-40a0-b7dd-8255f4191545)



